### PR TITLE
🚑️ sprintf for US country failed with: 3 arguments are required, 2 given

### DIFF
--- a/src/FinalMileCarrier/FinalMileCarrier.php
+++ b/src/FinalMileCarrier/FinalMileCarrier.php
@@ -179,7 +179,7 @@ class FinalMileCarrier
         'UY' => ['name' => self::CORREO_URUGUAYO, 'url' => 'https://www.correo.com.uy/seguimientodeenvios'],
         'US' => [
             'name' => self::USPS,
-            'url'  => 'https://tools.usps.com/go/TrackConfirmAction?tRef=fullpage&tLc=2&text28777=&tLabels=%s%2C&tABt=false',
+            'url'  => 'https://tools.usps.com/go/TrackConfirmAction?tRef=fullpage&tLc=2&text28777=&tLabels=%s&tABt=false',
         ],
     ];
 

--- a/tests/FinalMileCarrier/FinalMileCarrierTest.php
+++ b/tests/FinalMileCarrier/FinalMileCarrierTest.php
@@ -22,10 +22,13 @@ class FinalMileCarrierTest extends TestCase
         $this->assertEquals('bpost', (new FinalMileCarrier('BE', '12345678'))->getName());
     }
 
-    /** @test */
-    public function itShouldReturnTheTrackingCode(): void
+    /**
+     * @dataProvider carrierCountryCodeDataProvider
+     * @test
+     */
+    public function itShouldReturnTheTrackingCode(string $countryCode): void
     {
-        $this->assertEquals('12345678', (new FinalMileCarrier('BE', '12345678'))->getTrackingCode());
+        $this->assertEquals('12345678', (new FinalMileCarrier($countryCode, '12345678'))->getTrackingCode());
     }
 
     /** @test */
@@ -34,5 +37,67 @@ class FinalMileCarrierTest extends TestCase
         $this->expectException(CarrierNotSupportedException::class);
         $this->expectExceptionMessage('No carrier found for country code XX');
         new FinalMileCarrier('XX', '12345678');
+    }
+
+    public function carrierCountryCodeDataProvider(): array
+    {
+        return [
+            ['AR'],
+            ['AU'],
+            ['AT'],
+            ['BE'],
+            ['BR'],
+            ['BG'],
+            ['CA'],
+            ['CL'],
+            ['HR'],
+            ['CY'],
+            ['CZ'],
+            ['DK'],
+            ['EG'],
+            ['EE'],
+            ['FI'],
+            ['FR'],
+            ['DE'],
+            ['GH'],
+            ['GR'],
+            ['HK'],
+            ['HU'],
+            ['IS'],
+            ['IN'],
+            ['ID'],
+            ['IE'],
+            ['IT'],
+            ['JP'],
+            ['KP'],
+            ['LV'],
+            ['LT'],
+            ['LU'],
+            ['MY'],
+            ['MT'],
+            ['MX'],
+            ['NL'],
+            ['NZ'],
+            ['NG'],
+            ['NO'],
+            ['PH'],
+            ['PL'],
+            ['PT'],
+            ['RO'],
+            ['RU'],
+            ['SG'],
+            ['SK'],
+            ['SI'],
+            ['ZA'],
+            ['ES'],
+            ['SE'],
+            ['CH'],
+            ['TW'],
+            ['TH'],
+            ['TR'],
+            ['GB'],
+            ['UY'],
+            ['US'],
+        ];
     }
 }


### PR DESCRIPTION
Fix for: https://app.rollbar.com/a/myparcelcom/fix/item/microservice-postnl-ttint/61

I decided to remove `%2C` from the USPS link because that is equal to a comma and not needed for the URL to work.
`sprintf` tries to match a second parameter because of the `%` and fails, causing shipment registrations to fail.

We need to update all US-based microservicies with this fix - at least TTINT where this bug was reported.